### PR TITLE
빌드 중 Rollup이 prop-types 의존성을 해결하지 못한 오류 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^1.7.2",
         "markdown-it": "^14.1.0",
         "photoswipe": "^5.4.4",
+        "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.3.0",
@@ -2530,7 +2531,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2609,7 +2609,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -2619,8 +2618,7 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "peer": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/property-information": {
       "version": "6.5.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "axios": "^1.7.2",
     "markdown-it": "^14.1.0",
     "photoswipe": "^5.4.4",
+    "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0",


### PR DESCRIPTION
## 오류 내용
```
Run npm run build

> fe-seoul-nolgoat@0.1.0 build
> vite build

The CJS build of Vite's Node API is deprecated. See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
vite v5.4.11 building for production...
transforming...
✓ 113 modules transformed.
x Build failed in 643ms
error during build:
[vite]: Rollup failed to resolve import "prop-types" from "/home/runner/work/fe-seoul-nolgoat/fe-seoul-nolgoat/node_modules/react-photoswipe-gallery/dist/gallery.js".
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
`build.rollupOptions.external`
    at viteWarn (file:///home/runner/work/fe-seoul-nolgoat/fe-seoul-nolgoat/node_modules/vite/dist/node/chunks/dep-CB_[7](https://github.com/Seoul-NolGoat/fe-seoul-nolgoat/actions/runs/12715197407/job/35446906362#step:6:8)IfJ-.js:655[8](https://github.com/Seoul-NolGoat/fe-seoul-nolgoat/actions/runs/12715197407/job/35446906362#step:6:9)9:17)
    at onwarn (/home/runner/work/fe-seoul-nolgoat/fe-seoul-nolgoat/node_modules/@vitejs/plugin-react/dist/index.cjs:288:[9](https://github.com/Seoul-NolGoat/fe-seoul-nolgoat/actions/runs/12715197407/job/35446906362#step:6:10))
    at onRollupWarning (file:///home/runner/work/fe-seoul-nolgoat/fe-seoul-nolgoat/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:65619:5)
    at onwarn (file:///home/runner/work/fe-seoul-nolgoat/fe-seoul-nolgoat/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:65284:7)
    at file:///home/runner/work/fe-seoul-nolgoat/fe-seoul-nolgoat/node_modules/vite/node_modules/rollup/dist/es/shared/node-entry.js:19472:13
    at Object.logger [as onLog] (file:///home/runner/work/fe-seoul-nolgoat/fe-seoul-nolgoat/node_modules/vite/node_modules/rollup/dist/es/shared/node-entry.js:2[11](https://github.com/Seoul-NolGoat/fe-seoul-nolgoat/actions/runs/12715197407/job/35446906362#step:6:12)98:9)
    at ModuleLoader.handleInvalidResolvedId (file:///home/runner/work/fe-seoul-nolgoat/fe-seoul-nolgoat/node_modules/vite/node_modules/rollup/dist/es/shared/node-entry.js:20087:26)
    at file:///home/runner/work/fe-seoul-nolgoat/fe-seoul-nolgoat/node_modules/vite/node_modules/rollup/dist/es/shared/node-entry.js:20045:26
Error: Process completed with exit code 1.
```

## 해결 방법
prop-types 의존성을 추가 `npm install prop-types`
